### PR TITLE
Resolver error de tipos en vercel

### DIFF
--- a/src/app/event/[slug]/page.tsx
+++ b/src/app/event/[slug]/page.tsx
@@ -4,17 +4,18 @@ import { ScheduleGrid } from '@/components/ScheduleGrid';
 import { getEventBySlug } from '@/lib/api';
 import { notFound } from 'next/navigation';
 
-// ARREGLO DEFINITIVO:
-// Definimos el tipo 'Props' con el formato completo que Next.js espera
-// para una página, incluyendo 'params' y 'searchParams'.
+// ARREGLO DEFINITIVO PARA NEXT.JS 15.4.2:
+// En Next.js 15, los params son ahora promesas por defecto
 type Props = {
-  params: { slug: string };
-  searchParams: { [key: string]: string | string[] | undefined };
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-// Usamos el tipo 'Props' en nuestra función de página.
+// Función de página que maneja params como promesa
 export default async function EventPage({ params }: Props) {
-  const event = await getEventBySlug(params.slug);
+  // Esperamos a que se resuelva la promesa de params
+  const resolvedParams = await params;
+  const event = await getEventBySlug(resolvedParams.slug);
 
   if (!event) {
     notFound();


### PR DESCRIPTION
Fix Next.js 15.4.2 type error by handling dynamic route parameters as Promises.

Next.js 15.x now treats dynamic route parameters (`params` and `searchParams`) as Promises by default, requiring them to be awaited before access. This change resolves a persistent type error preventing Vercel deployments.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-04cf9e0d-d7cd-4a81-98c0-eef923cc6fd2) · [Cursor](https://cursor.com/background-agent?bcId=bc-04cf9e0d-d7cd-4a81-98c0-eef923cc6fd2)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)